### PR TITLE
Added ignore numbers variable argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5 (March 5, 2020)
+
+- added new optional argument `excluded-numbers` which can take in an array of numbers you wish to exclude from the scan
+
 ## 1.0.4 (December 10, 2019)
 
 - When `luhn-check` is enabled, `scanFile` will now run a luhn check before flagging a file. Previously the luhn check only affected console output logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.5 (March 5, 2020)
 
-- added new optional argument `excluded-numbers` which can take in an array of numbers you wish to exclude from the scan
+-  Add `ignore-numbers` argument which takes an array of numbers you want to ignore
 
 ## 1.0.4 (December 10, 2019)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccscan",
   "description": "Scan files for credit card numbers",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccscan",
   "description": "Scan files for credit card numbers",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,7 @@ const defaultArgs = {
   ignoreNumbers: [],
   luhnCheck: true,
   silent: false,
-  verbose: false,
+  verbose: false
 };
 
 const isCardNumber = (suspect: string, excludedNumbers?: string[]): boolean => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,10 +24,10 @@ const defaultArgs = {
   verbose: false
 };
 
-const isCardNumber = (suspect: string, excludedNumbers?: string[]): boolean => {
+const isCardNumber = (suspect: string, ignoreNumbers?: string[]): boolean => {
   const trimmedSuspect = suspect.replace(/[\s-]+/g, '');
 
-  return !excludedNumbers?.includes(trimmedSuspect) && luhn(trimmedSuspect);
+  return !ignoreNumbers?.includes(trimmedSuspect) && luhn(trimmedSuspect);
 }
 
 const showMatches = async (
@@ -168,7 +168,7 @@ const run = async (): Promise<void> => {
       describe: 'exclude pattern',
       type: 'array'
     })
-    .option('exclude-numbers', {
+    .option('ignore-numbers', {
       default: [],
       describe: 'ignore these numbers',
       type: 'array'

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -29,6 +29,14 @@ describe('TypeScript', () => {
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
+  test('card numbers are detected but excluded numbers are not included', async () => {
+    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', "exclude-numbers": ["5555554240233167"] })).toEqual([
+      'test/fixtures/typescript/bad.ts'
+    ]);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
+    expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
+  });
+
   test('card numbers are detected in silent mode', async () => {
     expect(
       await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', silent: true })
@@ -75,6 +83,14 @@ describe('JavaScript', () => {
     ]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(12);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
+  });
+
+  test('card numbers are detected but excluded numbers are not included', async () => {
+    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , "exclude-numbers": ["5555554240233167"] })).toEqual([
+      'test/fixtures/javascript/bad.js'
+    ]);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
+    expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
   });
 
   test('card numbers are detected in silent mode', async () => {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -29,7 +29,7 @@ describe('TypeScript', () => {
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
-  test('card numbers are detected but excluded numbers are not included', async () => {
+  test('card numbers are detected but ignored numbers are not included', async () => {
     expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167"] })).toEqual([
       'test/fixtures/typescript/bad.ts'
     ]);
@@ -85,7 +85,7 @@ describe('JavaScript', () => {
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
-  test('card numbers are detected but excluded numbers are not included', async () => {
+  test('card numbers are detected but ignored numbers are not included', async () => {
     expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([
       'test/fixtures/javascript/bad.js'
     ]);

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -30,7 +30,7 @@ describe('TypeScript', () => {
   });
 
   test('card numbers are detected but excluded numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', "exclude-numbers": ["5555554240233167"] })).toEqual([
+    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167"] })).toEqual([
       'test/fixtures/typescript/bad.ts'
     ]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
@@ -54,7 +54,7 @@ describe('TypeScript', () => {
 
   test('card-like numbers are detected when luhn check is disabled', async () => {
     expect(
-      await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', 'luhn-check': false })
+      await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', luhnCheck : false })
     ).toEqual(['test/fixtures/typescript/bad.ts', 'test/fixtures/typescript/questionable.ts']);
     expect(consoleLogSpy).toHaveBeenCalledTimes(24);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
@@ -86,7 +86,7 @@ describe('JavaScript', () => {
   });
 
   test('card numbers are detected but excluded numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , "exclude-numbers": ["5555554240233167"] })).toEqual([
+    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([
       'test/fixtures/javascript/bad.js'
     ]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
@@ -110,7 +110,7 @@ describe('JavaScript', () => {
 
   test('card-like numbers are detected when luhn check is disabled', async () => {
     expect(
-      await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}', 'luhn-check': false })
+      await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}', luhnCheck: false })
     ).toEqual(['test/fixtures/javascript/bad.js', 'test/fixtures/javascript/questionable.js']);
     expect(consoleLogSpy).toHaveBeenCalledTimes(24);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();


### PR DESCRIPTION
Updated ccscan to take in an optional `excluded-numbers` field where an array of numbers can be added and ignored in the ccscan