### PR TITLE
Fixing issues with the ignore-numbers argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 
 *.log
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 (September 24, 2020)
 
-- The `ignore-numbers` argument is now properly interpreted as an array of strings
+- The `ignore-numbers` argument is now properly interpreted as an array of strings.
 - The `ignore-numbers` argument is now respected when scanning files.
 
 ## 1.1.0 (March 9, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1 (September 24, 2020)
+
+- The `ignore-numbers` argument is now properly interpreted as an array of strings
+- The `ignore-numbers` argument is now respected when scanning files.
+
 ## 1.1.0 (March 9, 2020)
 
 -  Add `ignore-numbers` argument which takes an array of numbers you want to ignore

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccscan",
   "description": "Scan files for credit card numbers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -103,7 +103,7 @@ const scanFile = async (fileName: string, args: Args): Promise<boolean> => {
   if (matches && matches.length > 0) {
     !args.silent && (await showMatches(fileName, matches, args));
 
-    if (!args.luhnCheck || matches.filter(luhn).length > 0) {
+    if (!args.luhnCheck || matches.filter(match => isCardNumber(match, args.ignoreNumbers)).length > 0) {
       return true;
     }
   }
@@ -171,7 +171,8 @@ const run = async (): Promise<void> => {
     .option('ignore-numbers', {
       default: [],
       describe: 'ignore these numbers',
-      type: 'array'
+      type: 'array',
+      string: true
     })
     .option('luhn-check', {
       default: true,

--- a/test/__snapshots__/app.test.ts.snap
+++ b/test/__snapshots__/app.test.ts.snap
@@ -13,6 +13,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
 ]
 `;
@@ -30,6 +31,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
   "test/fixtures/javascript/good.js",
   "test/fixtures/javascript/questionable.js",
@@ -49,6 +51,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
   "test/fixtures/javascript/questionable.js",
   undefined,
@@ -61,6 +64,23 @@ Array [
   "  11:54    warn     const cardNumberInString = 'This is a card number: 1234123412341234';",
   "  12:43    warn     const cardNumberInStringNoSpaces = 'text1234123412341234text';",
   "  13:33    warn     const cardNumberWithThrees = '3333333333333333';",
+  undefined,
+]
+`;
+
+exports[`JavaScript files with both ignored and non-ignored card numbers are included 1`] = `
+Array [
+  "test/fixtures/javascript/bad.js",
+  undefined,
+  "  3:29     error  // card number in a comment 5555554240233167",
+  "  4:34     error  // two card numbers in a comment 5555554240233167 1234123412341234",
+  "  7:31     error    const cardNumberNoSpaces = '5555554240233167';",
+  "  8:34     error    const cardNumberSingleSpace = '5555 5542 4023 3167';",
+  "  9:33     error    const cardNumberSingleDash = '5555-5542-4023-3167';",
+  "  10:37    error    const cardNumberMultipleSpaces = '5555  5542  4023  3167';",
+  "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
+  "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
+  "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
   undefined,
 ]
 `;
@@ -78,6 +98,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
 ]
 `;
@@ -95,6 +116,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
   "test/fixtures/typescript/good.ts",
   "test/fixtures/typescript/questionable.ts",
@@ -114,6 +136,7 @@ Array [
   "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
   "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
   "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
+  "  15:37    error    const secondCardNumberNoSpaces = '5411119998052468';",
   undefined,
   "test/fixtures/typescript/questionable.ts",
   undefined,
@@ -126,6 +149,23 @@ Array [
   "  11:54    warn     const cardNumberInString = 'This is a card number: 1234123412341234';",
   "  12:43    warn     const cardNumberInStringNoSpaces = 'text1234123412341234text';",
   "  13:33    warn     const cardNumberWithThrees = '3333333333333333';",
+  undefined,
+]
+`;
+
+exports[`TypeScript files with both ignored and non-ignored card numbers are included 1`] = `
+Array [
+  "test/fixtures/typescript/bad.ts",
+  undefined,
+  "  3:29     error  // card number in a comment 5555554240233167",
+  "  4:34     error  // two card numbers in a comment 5555554240233167 1234123412341234",
+  "  7:31     error    const cardNumberNoSpaces = '5555554240233167';",
+  "  8:34     error    const cardNumberSingleSpace = '5555 5542 4023 3167';",
+  "  9:33     error    const cardNumberSingleDash = '5555-5542-4023-3167';",
+  "  10:37    error    const cardNumberMultipleSpaces = '5555  5542  4023  3167';",
+  "  11:37    error    const cardNumberMultipleDashes = '5555--5542--4023--3167';",
+  "  12:54    error    const cardNumberInString = 'This is a card number: 5555554240233167';",
+  "  13:43    error    const cardNumberInStringNoSpaces = 'text5555554240233167text';",
   undefined,
 ]
 `;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -86,9 +86,7 @@ describe('JavaScript', () => {
   });
 
   test('card numbers are detected but ignored numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([
-      'test/fixtures/javascript/bad.js'
-    ]);
+    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
   });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -25,14 +25,22 @@ describe('TypeScript', () => {
     expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}' })).toEqual([
       'test/fixtures/typescript/bad.ts'
     ]);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(12);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(13);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
   test('files with ignored card numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167"] })).toEqual([]);
+    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167", "5411119998052468"] })).toEqual([]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
+  });
+
+  test('files with both ignored and non-ignored card numbers are included', async () => {
+    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5411119998052468"] })).toEqual([
+      'test/fixtures/typescript/bad.ts'
+    ]);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(12);
+    expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
   test('card numbers are detected in silent mode', async () => {
@@ -46,7 +54,7 @@ describe('TypeScript', () => {
     expect(
       await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', verbose: true })
     ).toEqual(['test/fixtures/typescript/bad.ts']);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(14);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(15);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
@@ -54,7 +62,7 @@ describe('TypeScript', () => {
     expect(
       await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', luhnCheck : false })
     ).toEqual(['test/fixtures/typescript/bad.ts', 'test/fixtures/typescript/questionable.ts']);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(24);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(25);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
@@ -79,14 +87,22 @@ describe('JavaScript', () => {
     expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' })).toEqual([
       'test/fixtures/javascript/bad.js'
     ]);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(12);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(13);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
   test('files with ignored card numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([]);
+    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167", '5411119998052468'] })).toEqual([]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
+  });
+
+  test('files with both ignored and non-ignored card numbers are included', async () => {
+    expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}', ignoreNumbers: ["5411119998052468"] })).toEqual([
+      'test/fixtures/javascript/bad.js'
+    ]);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(12);
+    expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
   test('card numbers are detected in silent mode', async () => {
@@ -100,7 +116,7 @@ describe('JavaScript', () => {
     expect(
       await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}', verbose: true })
     ).toEqual(['test/fixtures/javascript/bad.js']);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(14);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(15);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
@@ -108,7 +124,7 @@ describe('JavaScript', () => {
     expect(
       await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}', luhnCheck: false })
     ).toEqual(['test/fixtures/javascript/bad.js', 'test/fixtures/javascript/questionable.js']);
-    expect(consoleLogSpy).toHaveBeenCalledTimes(24);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(25);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -85,7 +85,7 @@ describe('JavaScript', () => {
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
-  test('card numbers are detected but ignored numbers are not included', async () => {
+  test('files with ignored card numbers are not included', async () => {
     expect(await scanFiles({ files: '**/test/fixtures/javascript/*.{ts,js}' , ignoreNumbers: ["5555554240233167"] })).toEqual([]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -29,10 +29,8 @@ describe('TypeScript', () => {
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toMatchSnapshot();
   });
 
-  test('card numbers are detected but ignored numbers are not included', async () => {
-    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167"] })).toEqual([
-      'test/fixtures/typescript/bad.ts'
-    ]);
+  test('files with ignored card numbers are not included', async () => {
+    expect(await scanFiles({ files: '**/test/fixtures/typescript/*.{ts,js}', ignoreNumbers: ["5555554240233167"] })).toEqual([]);
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(formatConsoleOutput(consoleLogSpy.mock.calls)).toHaveLength(0)
   });

--- a/test/fixtures/javascript/bad.js
+++ b/test/fixtures/javascript/bad.js
@@ -11,6 +11,8 @@ const doSomething = () => {
   const cardNumberMultipleDashes = '5555--5542--4023--3167';
   const cardNumberInString = 'This is a card number: 5555554240233167';
   const cardNumberInStringNoSpaces = 'text5555554240233167text';
+
+  const secondCardNumberNoSpaces = '5411119998052468';
 };
 
 module.export = doSomething;

--- a/test/fixtures/typescript/bad.ts
+++ b/test/fixtures/typescript/bad.ts
@@ -11,6 +11,8 @@ const doSomething = () => {
   const cardNumberMultipleDashes = '5555--5542--4023--3167';
   const cardNumberInString = 'This is a card number: 5555554240233167';
   const cardNumberInStringNoSpaces = 'text5555554240233167text';
+
+  const secondCardNumberNoSpaces = '5411119998052468';
 };
 
 export default doSomething;


### PR DESCRIPTION
- The argument is now respected when scanning files

- When used in the command line, the argument is now parsed as an array of strings
