### PR TITLE
Improve glob for excluding node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.1.2 (October 17, 2020)
+
 - Changed `node_modules` glob pattern to also exclude nested node_modules
 
 ## 1.1.1 (September 24, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2 (October 17, 2020)
+- Changed `node_modules` glob pattern to also exclude nested node_modules
+
 ## 1.1.1 (September 24, 2020)
 
 - The `ignore-numbers` argument is now properly interpreted as an array of strings.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ccscan",
   "description": "Scan files for credit card numbers",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "main": "build/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,7 +118,7 @@ const scanFiles = async (args: Args): Promise<string[]> => {
   const found = [];
 
   try {
-    const pattern = [mergedArgs.files, '!**/node_modules**', '!**/node_modules/**'];
+    const pattern = [mergedArgs.files, '!**/node_modules'];
 
     mergedArgs.exclude &&
       mergedArgs.exclude.forEach((exclude: string): void => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,7 +118,7 @@ const scanFiles = async (args: Args): Promise<string[]> => {
   const found = [];
 
   try {
-    const pattern = [mergedArgs.files, '!node_modules'];
+    const pattern = [mergedArgs.files, '!**/node_modules**', '!**/node_modules/**'];
 
     mergedArgs.exclude &&
       mergedArgs.exclude.forEach((exclude: string): void => {


### PR DESCRIPTION
Added two glob patterns to exclude nested `node_modules`.

<img width="300" alt="Screen Shot 2020-10-17 at 6 15 03 PM" src="https://user-images.githubusercontent.com/2881382/96355908-c9210f00-10a4-11eb-9c03-86f214544b37.png">
<img width="300" alt="Screen Shot 2020-10-17 at 6 14 58 PM" src="https://user-images.githubusercontent.com/2881382/96355910-cc1bff80-10a4-11eb-8f5a-b7b6e96499a1.png">

Tried making it work with one pattern only but just adding two patterns seemed easier 